### PR TITLE
fix a bug: when the value changes from 1-31(>29/28) to 2-31

### DIFF
--- a/SSFlatDatePicker.m
+++ b/SSFlatDatePicker.m
@@ -542,6 +542,10 @@
         if (currentDayIndex+1 > days) {
             currentDayIndex = days - 1;
         }
+    }else if(currentMonthIndex==1 || currentMonthIndex==3 || currentMonthIndex==5 || currentMonthIndex==8 || currentMonthIndex==10){
+        if (currentDayIndex+1 > 30) {
+            currentDayIndex = 29;
+        }
     }
     
   dComps.year = currentYearIndex + self.yearRange.location;


### PR DESCRIPTION
原来用中文也可以。。。首先感谢一下你贡献的这个控件啊。
我遇到的问题是如果当前显示的日期是比如2013-3-30，然后滚动月选择器到2月，此时显示2013-2-30。我们希望看到的结果应该是日选择器自动滚到28号。但是此时通过date属性得到的日期为2013-3-2号，而collection view的更新逻辑是根据3月二号来更新的，日选择器依然显示2月有31天，这显然是不正确的。从2013-3-31改到2013-4-31也有同样的问题。
我在自己的项目中做了点修改，可能不是最好的方法。主要是想询问一下你对这个问题的看法，或许我们的逻辑不同，是不是有更好的解决方法呢。
