### PR TITLE
Fixed 'control may reach end of non void function' warning

### DIFF
--- a/SSFlatDatePicker.m
+++ b/SSFlatDatePicker.m
@@ -417,35 +417,41 @@
 }
 
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+  
+  NSInteger numberOfItems = 0;
+  
   if (collectionView == self.scrollerYear) {
     
-    return self.yearRange.length;
+    numberOfItems = self.yearRange.length;
     
   } else if (collectionView == self.scrollerMonth) {
     
-    return 12;
+    numberOfItems = 12;
     
   } else if (collectionView == self.scrollerDay) {
+    
     if (self.date) {
       NSRange dayRange = [[NSCalendar currentCalendar] rangeOfUnit:NSDayCalendarUnit inUnit:NSMonthCalendarUnit forDate:self.date];
-      return dayRange.length;
+      numberOfItems = dayRange.length;
+    } else {
+      numberOfItems = 31;
     }
     
-    return 31;
   } else if (collectionView == self.scrollerHour) {
     
-    return 12;
+    numberOfItems = 12;
     
   } else if (collectionView == self.scrollerMinute) {
     
-    return 60;
+    numberOfItems = 60;
     
   } else if (collectionView == self.scrollerAPM) {
     
-    return 2;
+    numberOfItems = 2;
     
   }
 
+  return numberOfItems;
 }
 
 


### PR DESCRIPTION
It seems like the default compiler setting in Xcode 5 starts treating this warning as an error and fails the compilations of the library.

http://stackoverflow.com/questions/18908129/xcode-5-what-was-a-warning-now-an-error-control-may-reach-end-of-non-void-func

Experienced using version 0.0.6 as a pod dependency. Cocoapods version 0.26.2.
