### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,6 @@ And also watch the sample app video here: http://youtu.be/ROgQzdq8CXg
 4. Or, you can drag a UIView retangle in Interface Builder, set its custom class as SSFlatDatePicker, and link to the IBOutlet in your source code. 
 5. You can hook the changed value throught monitoring the UIControlEventValueChanged event. 
 
-## Cocoapods
+## CocoaPods
 SSFlatDatePicker is in cocoapods now, you can find it and install it throught pods command. 
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
